### PR TITLE
Recycle messages from reliable packets

### DIFF
--- a/Hazel/Connection.cs
+++ b/Hazel/Connection.cs
@@ -191,7 +191,13 @@ namespace Hazel
                 {
                     handler(new DataReceivedEventArgs(this, msg, sendOption));
                 }
-                catch { }
+                catch
+                {
+                }
+                finally
+                {
+                    msg.Recycle();
+                }
             }
             else
             {


### PR DESCRIPTION
Currently the packets aren't being recycled, causing a memory leak.